### PR TITLE
Refactor: force transform unknown command to UInt64

### DIFF
--- a/ALCPlugFix-Swift/Constants/Constants.swift
+++ b/ALCPlugFix-Swift/Constants/Constants.swift
@@ -69,7 +69,7 @@ fileprivate let hdaVerbs: [String : UInt64] = [
 ]
 
 func getUint64Verb(from stringCommand: String) -> UInt64 {
-    return hdaVerbs[stringCommand] ?? 0
+    return hdaVerbs[stringCommand] ?? stringCommand.toUInt64()
 }
 
 extension String {


### PR DESCRIPTION
Fixes #12.

I haven't checked what goes wrong, but currently, it is impossible for `0x20, SET_PROC_COEF, 0xb020` to work (checked with `alc-verb`). It can only be workaround by using `0x20 0x4b0 0x20`.

Here I modify the `getUint64Verb` function, make it passes the original command when it is not found in `hdaVerbs`.

After the changes, #12 would be fixed.